### PR TITLE
remove unneeded imports: os, zipfile and show_alert

### DIFF
--- a/swappanels/__init__.py
+++ b/swappanels/__init__.py
@@ -1,6 +1,4 @@
-from fman import DirectoryPaneCommand, show_alert
-import os
-import zipfile
+from fman import DirectoryPaneCommand
 
 class SwapPanel(DirectoryPaneCommand):
     def __call__(self):


### PR DESCRIPTION
Removing imports plugin doesn't use.